### PR TITLE
Added button IDs for shared callback functions.

### DIFF
--- a/EButton.cpp
+++ b/EButton.cpp
@@ -1,9 +1,10 @@
 #include "EButton.h"
 
-EButton::EButton(byte pin, bool pressedLow) {
+EButton::EButton(byte pin, bool pressedLow, byte id) {
 	this->pin = pin;
 	pinMode(pin, pressedLow ? INPUT_PULLUP : INPUT);
 	pressedState = !pressedLow;
+	this->id = id;
 	reset();
 }
 
@@ -75,6 +76,10 @@ void EButton::reset() {
 
 byte EButton::getPin() {
 	return pin;
+}
+
+byte EButton::getID() {
+	return id;
 }
 
 byte EButton::getClicks() {

--- a/EButton.h
+++ b/EButton.h
@@ -101,7 +101,7 @@ typedef void (*EButtonEventHandler)(EButton&);
 class EButton {
 public:
 	// Constructor.
-	EButton(byte pin, bool pressedLow = true);
+	EButton(byte pin, bool pressedLow = true, byte id = 0);
 
 	// Debounce time - delay after the first transition, before sampling the next state.
 	void setDebounceTime(byte time);
@@ -153,6 +153,9 @@ public:
 	// Attached pin number
 	byte getPin();
 
+	// Button ID
+	byte getID();
+
 	// Number of clicks performed
 	byte getClicks();
 
@@ -178,6 +181,7 @@ private:
 
 	// ----- Configuration-specific fields -----
 	byte pin;										// Attached pin
+	byte id;										// Button ID
 	byte debounceTime = EBUTTON_DEFAULT_DEBOUNCE;	// Debounce time in ms (between 0 and 255)
 #if defined(EBUTTON_SUPPORT_DONE_CLICKING) || defined(EBUTTON_SUPPORT_SINGLE_AND_DOUBLE_CLICKS)
 	unsigned int clickTime = EBUTTON_DEFAULT_CLICK;	// Time the button has to be released in order to complete counting clicks

--- a/examples/SharedCallback/SharedCallback.ino
+++ b/examples/SharedCallback/SharedCallback.ino
@@ -1,0 +1,25 @@
+#include "EButton.h"
+
+EButton buttons[] = {
+  {6, true, 1}, {4, true, 2}, {2, true, 3},
+  {7, true, 4}, {5, true, 5}, {3, true, 6}};
+
+
+void sharedClick(EButton& btn) {
+  Serial.println(btn.getID());
+}
+
+
+void setup() {
+  Serial.begin(115200);
+
+  for (EButton& btn: buttons) {
+    btn.attachSingleClick(sharedClick);
+  }
+}
+
+void loop() {
+  for (EButton& btn: buttons) {
+    btn.tick();
+  }
+}


### PR DESCRIPTION
On multiple occasions [[1](https://forum.arduino.cc/t/accessing-instance-in-callback/1034382), [2](https://forum.arduino.cc/t/can-somebody-create-a-code-for-me/1029913)] I found that having a customisable button ID can substantially reduce the amount of callback functions needed, especially when a large number of buttons are used that nearly have the same function.

This PR adds an optional parameter named `id` to the constructor and a `getID` member function is added to retrieve the ID, analogous to the `getPin` member function. An example is included.

Please see this working [demo](https://wokwi.com/projects/343525241022054996) of the included example.